### PR TITLE
Added ability to move the border of the pullquote to the top of the pull quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Option | Accepts | Description | Example
 <code>color</code> | [HEX](http://www.colorhexa.com/) color code | Change the default <code>border-color</code> attribute by entering a valid HEX color, including the <kbd>#</kbd> | <code>[perfectpullquote align="left" color="#16989D"][/perfectpullquote]</code>
 <code>class</code> | text | Add class(es) to pullquote container. **Optional** | <code>[perfectpullquote align ="right" class="cited author-quote"][/perfectpullquote]</code>
 <code>size</code> | integer | Change the size, in pixels, of the pullquote's text. **Optional** | <code>[perfectpullquote align ="right" size="32"][/perfectpullquote]</code>
+<code>border_loc</code> | <code>top</code> <code>default</code> | Change the border location of the pullquote **Optional** | <code>[perfectpullquote align ="right" border_loc="top"][/perfectpullquote]</code>
 
 ## FAQ
 ##### Are all of the shortcode option attributes required?

--- a/perfect-pullquotes.css
+++ b/perfect-pullquotes.css
@@ -71,7 +71,7 @@
     margin: 0.5em 1.5em 1em 0;
     padding-left: 0;
     float: left;
-    border-right: 5px solid #eeeeee;
+    
 }
 
 .pullquote-align-right {
@@ -79,7 +79,7 @@
     margin: 0.5em 0 1em 1.5em;
     padding-right: 0;
     float: right;
-    border-left: 5px solid #eeeeee;
+    
 }
 
 .pullquote-align-full {
@@ -87,7 +87,19 @@
     margin: 0.5em 0 1em 1.5em;
     padding-right: 0;
     float: none;
+    
+}
+
+.border-place-left{
     border-left: 5px solid #eeeeee;
+}
+.border-place-right{
+    border-right: 5px solid #eeeeee;
+}
+.border-place-top{
+    border-top: 5px solid #eeeeee;
+    padding-left:.5em;
+	padding-right: .5em;
 }
 
 @media screen and (min-width: 769px) and (max-width: 992px) {
@@ -108,6 +120,7 @@
         width:95% !important;
         border-left: 5px solid #eeeeee;
         border-right: none !important;
+        border-top: none !important;
         float:none;
     }
 }

--- a/perfect-pullquotes.js
+++ b/perfect-pullquotes.js
@@ -24,21 +24,21 @@
             ed.addCommand('perfectpullquote-left', function() {
                 var selected_text = ed.selection.getContent();
                 var return_text = '';
-                return_text = '[perfectpullquote align="left" cite="" link="" color="" class="" size=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
+                return_text = '[perfectpullquote align="left" cite="" link="" color="" class="" size="" border_loc=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
                 ed.execCommand('mceInsertContent', 0, return_text);
             });
             // Right-Aligned Pullquote
             ed.addCommand('perfectpullquote-right', function() {
                 var selected_text = ed.selection.getContent();
                 var return_text = '';
-                return_text = '[perfectpullquote align="right" cite="" link="" color="" class="" size=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
+                return_text = '[perfectpullquote align="right" cite="" link="" color="" class="" size="" border_loc=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
                 ed.execCommand('mceInsertContent', 0, return_text);
             });
             // Right-Aligned Pullquote
             ed.addCommand('perfectpullquote-full', function() {
                 var selected_text = ed.selection.getContent();
                 var return_text = '';
-                return_text = '[perfectpullquote align="full" cite="" link="" color="" class="" size=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
+                return_text = '[perfectpullquote align="full" cite="" link="" color="" class="" size="" border_loc=""]' + selected_text.replace(/<\/?p[^>]*>/g, " ") + '[/perfectpullquote]<br/><br/>';
                 ed.execCommand('mceInsertContent', 0, return_text);
             });
             // Pullquote Menu Button http://www.tinymce.com/wiki.php/api4:class.tinymce.ui.MenuButton

--- a/perfect-pullquotes.php
+++ b/perfect-pullquotes.php
@@ -24,9 +24,13 @@ function adamdehaven_perfectpullquote( $atts, $content = null ) {
         'color' => null, // (Optional) Provide the HEX value of the border-color. Default #EEEEEE
         'class' => null, // (Optional) Add additional classes to the div.pullquote object
         'size'  => null, // (Optional) Define the font size of the text in pixels
+        'border_loc' => 'default', // (Optional, defaults to left or right) Options to change border location to either the top, or leave it 'defaulting' to the left or right.
+        
         ), $atts );
 
     // Pullquote alignment (left, right, or full)
+    
+    
     $alignment = '';
     switch ( $a['align'] ) {
         case 'full':
@@ -39,7 +43,24 @@ function adamdehaven_perfectpullquote( $atts, $content = null ) {
             $alignment = ' pullquote-align-left';
             break;
     }
-
+    
+    //Check for border location options.
+    $border = '';
+    switch ($a['border_loc']){
+        case 'top':
+            $border = " border-place-top";
+            break;
+        default:
+            if ($a['align'] == 'right') {
+                $border = " border-place-right";
+            } else {
+                $border = " border-place-left";
+            }
+            break;
+    }
+    
+    
+        
     // Check for classes
     if ( isset($a['class']) && strlen($a['class']) > 0 && preg_match('/[a-zA-Z0-9_ -]*/', $a['class']) ):
         $classes = strip_tags($classes);
@@ -65,8 +86,8 @@ function adamdehaven_perfectpullquote( $atts, $content = null ) {
         $color = null;
     endif;
 
-    if( !is_null($color) || !is_null($size) ):
-        $styles = ' style="'.$color.$size.'"';
+    if( !is_null($color) || !is_null($size)):
+        $styles = ' style="'.$color.$size. '"';
     else:
         $styles = null;
     endif;
@@ -98,7 +119,7 @@ function adamdehaven_perfectpullquote( $atts, $content = null ) {
         $citeFooter = null;
     endif;
 
-    return '<div class="perfect-pullquote vcard'.$alignment.$classes.'"'.$styles.'><blockquote'.$citeAttribute.'><p'.$paragraphSize.'>'.do_shortcode($content).'</p>'.$citeFooter.'</blockquote></div>';
+    return '<div class="perfect-pullquote vcard'.$alignment.$border.$classes.'"'.$styles.'><blockquote'.$citeAttribute.'><p'.$paragraphSize.'>'.do_shortcode($content).'</p>'.$citeFooter.'</blockquote></div>';
 }
 add_action( 'init', 'adamdehaven_buttons' );
 function adamdehaven_buttons() {


### PR DESCRIPTION
Love this plugin - and I love the fact that it's open source even more.

I had a client that needed pullquotes that were more in line with the way that Wired magazine does theirs - with the border at the top of the quote, so I made a few changes to the base, and thought you might want to include it in the plugin itself.

It still moves the border to the left if it's on mobile, because while at first I did have it stay on top, it really doesn't look good to do so.

If you're not interested in including these changes, that's fine!  Just thought you might want to have a look!